### PR TITLE
feat: add new stream keys and go live docs to /go/

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -22,4 +22,4 @@ jobs:
           cmd: install
 
       - name: Build project
-        run: npm run build
+        run: yarn build

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -20,4 +20,4 @@ jobs:
           cache-dependency-path: "yarn.lock"
       - run: yarn install --immutable --inline-builds
 
-      - run: yarn prettier --check .
+      - run: yarn format:check

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
-    "start": "serve out",
-    "lint": "next lint"
+    "start": "serve out"
   },
   "dependencies": {
     "@mantine/core": "^8.3.14",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
-    "start": "serve out"
+    "start": "serve out",
+    "format": "yarn prettier --write .",
+    "format:check": "yarn prettier --check ."
   },
   "dependencies": {
     "@mantine/core": "^8.3.14",

--- a/src/app/go/[go]/page.tsx
+++ b/src/app/go/[go]/page.tsx
@@ -1,12 +1,14 @@
 import { notFound } from "next/navigation";
 
 const GO_LINKS: Record<string, string> = {
-  // "stream-keys":
-  //   "https://docs.google.com/spreadsheets/d/12LvxeXGz3GcIUrza5TVJ6PbAsd7t6gQXDRj_jFvKFgk/edit?gid=0#gid=0",
+  "stream-keys":
+    "https://docs.google.com/spreadsheets/d/1qS8OwamoewnmYAvtTOGrL3jk13RPYjKEivv9ZuRM8p4/edit?usp=sharing",
   // live: "https://docs.google.com/document/d/1kQcz9uh8wqEfJqCae-_olfhB3wvBGgQV1QxGBcpwnQo/edit?tab=t.0",
   // "la1-guides":
   //   "https://drive.google.com/drive/u/0/folders/14Ake1gV-kIoC3aLVU-DZrLuLeyZPfFNv",
   // "vase-go-live": "https://youtu.be/sr-xGQ2_ViI",
+  "go-live":
+    "https://docs.google.com/document/d/1Kf-JrQGgnZC1zx2cWZDXoHfXW426jh4SJrzF2jNt0Uo/edit?usp=sharing",
   interest: "https://forms.gle/4hWkP7ZQfrFoRcJC9",
   "accomm-interest":
     "https://docs.google.com/forms/d/e/1FAIpQLSeZQyWAWyybXaxrDp4a6NEZOtLoDY1SwbHY8uklTl9h0uMp4w/viewform",


### PR DESCRIPTION
also removes the `lint` script from package.json because the `next lint` command seems to be kill